### PR TITLE
Require a filename for cloud merge and cloud read subcommands

### DIFF
--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -16,7 +16,7 @@ pub fn cloud_get_command(options: CloudGetOptions) -> Result<(), Error> {
 }
 
 pub fn cloud_merge_command(options: CloudMergeOptions) -> Result<(), Error> {
-    let ranges = load_cloud_ranges(&options.service, options.file.as_ref())?;
+    let ranges = load_cloud_ranges(&options.service, options.file)?;
 
     cloud_process_ranges(
         ranges,
@@ -52,7 +52,7 @@ pub fn cloud_get_merge_command(options: CloudGetMergeOptions) -> Result<(), Erro
 }
 
 pub fn cloud_read_command(options: CloudReadOptions) -> Result<(), Error> {
-    let ranges = load_cloud_ranges(&options.service, options.file.as_ref())?;
+    let ranges = load_cloud_ranges(&options.service, options.file)?;
 
     cloud_process_ranges(
         ranges,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ pub struct CloudMergeOptions {
     #[structopt(possible_values = get_cloud_names())]
     pub service: String,
 
-    /// File to load the ip ranges from. STDIN is used if not
-    /// specified.
-    pub file: Option<PathBuf>,
+    /// File to load the ip ranges from. STDIN is used if
+    /// file is "-".
+    pub file: PathBuf,
 
     /// Lua filter program to filter the ranges of interest.
     #[structopt(long, conflicts_with = "filter-file")]
@@ -178,9 +178,9 @@ pub struct CloudReadOptions {
     #[structopt(possible_values = get_cloud_names())]
     pub service: String,
 
-    /// File to load the ip ranges from. STDIN is used if not
-    /// specified.
-    pub file: Option<PathBuf>,
+    /// File to load the ip ranges from. STDIN is used if
+    /// file is "-".
+    pub file: PathBuf,
 
     /// Lua filter program to select the ranges of interest.
     #[structopt(long, conflicts_with = "filter-file")]

--- a/src/utils/load_ranges.rs
+++ b/src/utils/load_ranges.rs
@@ -19,17 +19,14 @@ pub fn fetch_and_load_cloud_ranges(service: &str) -> Result<Vec<RangesWithMetada
 
 /// Load ranges from a file for the named service into a Vec<RangesWithMetadata>
 /// suitable for filtering and selecting.
-pub fn load_cloud_ranges(
-    service: &str,
-    file: Option<&PathBuf>,
-) -> Result<Vec<RangesWithMetadata>, Error> {
+pub fn load_cloud_ranges(service: &str, file: PathBuf) -> Result<Vec<RangesWithMetadata>, Error> {
     let stdin = io::stdin();
     let cc = get_cloud_config(service)?;
     let load_func = cc.load_ranges_func;
-    let ranges = if let Some(file) = file {
-        load_func(&mut File::open(&file)?)?
-    } else {
+    let ranges = if let Some("-") = file.as_path().to_str() {
         load_func(&mut stdin.lock())?
+    } else {
+        load_func(&mut File::open(&file)?)?
     };
     Ok(ranges)
 }


### PR DESCRIPTION
Previously, if no filename was specified, we read from STDIN. This could
create some confusion if the filename wasn't specified by mistake
resulting in the command hanging forever waiting for STDIN to supply the
ip ranges. Now, we require that a filename of "-" be specified if the
user intends for the ip ranges to be read from STDIN. If the user
actually wants to read the ranges from a file named "-" (which seems
unlikely), they can specify the file as "./-".