### PR TITLE
Also require the file argument for the "merge" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ netrange cloud filter-help aws
 
 The `merge` subcommand will read in a list of IP
 ranges from the given file (or STDIN if no file is
-provided), merge adjacent ranges, and then print
+"-"), merge adjacent ranges, and then print
 the resulting ranges to STDOUT.
 
 ```sh

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -8,10 +8,10 @@ use std::io::{self, Write as _};
 
 pub fn merge_command(options: MergeOptions) -> Result<(), Error> {
     let mut ranges = Vec::new();
-    if let Some(file) = options.file {
-        read_single_line_ranges(&mut File::open(&file)?, &mut ranges, true)?
-    } else {
+    if let Some("-") = options.file.as_path().to_str() {
         read_single_line_ranges(&mut io::stdin().lock(), &mut ranges, true)?
+    } else {
+        read_single_line_ranges(&mut File::open(&options.file)?, &mut ranges, true)?
     };
 
     for extra_file in options.extra_ranges_files.into_iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,8 +235,9 @@ pub struct CloudFilterHelpOptions {
 /// The minimized set of ranges will be printed to STDOUT.
 #[derive(Debug, StructOpt)]
 pub struct MergeOptions {
-    /// The file to read ranges from
-    pub file: Option<PathBuf>,
+    /// The file to read ranges from. STDIN is used if
+    /// file is "-".
+    pub file: PathBuf,
 
     /// Extra ranges that may be helpful to minimize the set
     ///


### PR DESCRIPTION
This makes the "merge" subcommand behave the same as the "cloud read"
and "cloud merge" subcommands.