### PR TITLE
Add #[allow(dead_code)] to stop warning about unused fields in Serde structs

### DIFF
--- a/src/sources/azure.rs
+++ b/src/sources/azure.rs
@@ -24,7 +24,7 @@ https://docs.microsoft.com/en-us/rest/api/virtualnetwork/servicetags/list
 "###;
 
 #[derive(Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[allow(non_snake_case, dead_code)]
 struct AzureRanges {
     changeNumber: i64,
     cloud: String,
@@ -39,7 +39,7 @@ struct AzureRange {
 }
 
 #[derive(Deserialize, Debug)]
-#[allow(non_snake_case)]
+#[allow(non_snake_case, dead_code)]
 struct AzureRangeProperties {
     changeNumber: i64,
     region: String,

--- a/src/sources/cloudflare.rs
+++ b/src/sources/cloudflare.rs
@@ -15,6 +15,7 @@ Cloudflare IP ranges are published at: https://api.cloudflare.com/client/v4/ips
 "###;
 
 #[derive(Deserialize, Debug)]
+#[allow(dead_code)]
 struct CloudflareRanges {
     result: CloudflareRangesResult,
     success: bool,


### PR DESCRIPTION
We could also remove the fields - but, I do think its nice to better
reflect what is actually in the response.